### PR TITLE
[RELEASE] v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-performance-limiter",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A package for deliberately limiting the performance of React Native applications",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/react-native-performance-limiter.podspec
+++ b/react-native-performance-limiter.podspec
@@ -1,7 +1,6 @@
 require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
-folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
   s.name         = "react-native-performance-limiter"
@@ -16,20 +15,5 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/**/*.{h,m,mm}"
 
-  s.dependency "React-Core"
-
-  # Don't install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-  end
+  install_modules_dependencies(s)
 end


### PR DESCRIPTION
### What and why?

Prepares 0.3.0 release and updates the .podspec to use `install_modules_dependencies(s)` as specified in the [official guide](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/turbo-modules.md#ios-create-the-podspec-file) for **Turbo Modules**.

### Motivation

Fixes iOS build issue: `ReactCommon/TurboModuleBinding.h' file not found`
