### PR TITLE
[CHORE] Add Publish action and lock actions to specific commit hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '18.0.0'
       - run: yarn install --immutable
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '18.0.0'
       - run: yarn install --immutable

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,11 +25,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@80cb6b56b93de3e779c7d476d9100d06fb87c877 # v2.23.2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -43,7 +43,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@80cb6b56b93de3e779c7d476d9100d06fb87c877 # v2.23.2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@80cb6b56b93de3e779c7d476d9100d06fb87c877 # v2.23.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish packages on NPM
+on:
+  # release:
+  #   types: [created]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: Production
+    permissions:
+            id-token: write
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: '24.x'
+    - run: corepack enable
+    - run: yarn install --immutable
+    - run: yarn prepack
+    - run: npm publish --dry-run

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "engines": {
     "node": ">= 16.0.0"
   },
-  "packageManager": "^yarn@1.22.15",
+  "packageManager": "yarn@4.3.1",
   "jest": {
     "preset": "react-native",
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
### What and why?

This PR does two things:

- Adds a publish action for the package (in dry-run mode first)
- Locks actions such as checkout and codeql-actions to a particular commit-hash instead of a version.

### How?
- Adds a publish action that does not rely on NPM tokens.
- Simply locking each version to a commit hash instead of a version number.

### Review checklist

- [ ] Feature or bugfix MUST have appropriate tests (unit)
